### PR TITLE
feat: publish error reply when a component fails

### DIFF
--- a/deployment/src/test/java/io/github/amadeusitgroup/flamme/test/ComponentFailureTest.java
+++ b/deployment/src/test/java/io/github/amadeusitgroup/flamme/test/ComponentFailureTest.java
@@ -1,0 +1,39 @@
+package io.github.amadeusitgroup.flamme.test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.StringValue;
+import io.github.amadeusitgroup.flamme.test.fixtures.Components;
+import io.quarkus.test.QuarkusUnitTest;
+import jakarta.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ComponentFailureTest {
+
+  @Inject Components.Gateway gateway;
+
+  @RegisterExtension
+  static final QuarkusUnitTest unitTest =
+      new QuarkusUnitTest()
+          .setArchiveProducer(
+              () ->
+                  ShrinkWrap.create(JavaArchive.class)
+                      .addClass(Components.Gateway.class)
+                      .addClass(Components.FailingComponent.class)
+                      .addClass(Components.FailingComponentImpl.class));
+
+  @Test
+  void futureShouldCompleteExceptionallyWhenComponentThrows() {
+    Any payload = Any.pack(StringValue.of("Hello World"));
+    CompletableFuture<Any> resultFuture = gateway.call(payload);
+    CompletionException ex = assertThrows(CompletionException.class, resultFuture::join);
+    assertTrue(ex.getMessage().contains("failing component failed"));
+  }
+}

--- a/deployment/src/test/java/io/github/amadeusitgroup/flamme/test/RemoteComponentsTest.java
+++ b/deployment/src/test/java/io/github/amadeusitgroup/flamme/test/RemoteComponentsTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.StringValue;
+import io.github.amadeusitgroup.flamme.runtime.FlammeEnvelope;
 import io.github.amadeusitgroup.flamme.runtime.errors.FlammeImplRuntimeError;
 import io.github.amadeusitgroup.flamme.runtime.payload.MultiPayloadCodec;
 import io.github.amadeusitgroup.flamme.runtime.payload.PayloadCodec;
@@ -70,18 +71,24 @@ public class RemoteComponentsTest {
     Dispatcher dispatcher = natsClientManager.getConnection().createDispatcher();
     CompletableFuture<StringValue> resultFuture = new CompletableFuture<>();
     Any payload = Any.pack(StringValue.of("Hello"));
+    FlammeEnvelope envelope = FlammeEnvelope.newBuilder().setPayload(payload).build();
     dispatcher.subscribe(
         "INBOX.>",
         (message) -> {
           try {
             StringValue result =
-                payloadCodec.decodePayload(message.getData()).unpack(StringValue.class);
+                payloadCodec
+                    .decodePayload(message.getData())
+                    .getPayload()
+                    .unpack(StringValue.class);
             resultFuture.complete(result);
           } catch (InvalidProtocolBufferException | FlammeImplRuntimeError e) {
             fail(Strings.FAILED_TO_READ_PAYLOAD);
           }
         });
-    natsClientManager.getConnection().publish("fan-out-event", "INBOX.test-reply", encode(payload));
+    natsClientManager
+        .getConnection()
+        .publish("fan-out-event", "INBOX.test-reply", payloadCodec.encodePayload(envelope));
     try {
       StringValue result = resultFuture.get(5, TimeUnit.SECONDS);
       assertEquals(StringValue.of("Hello"), result);
@@ -101,7 +108,10 @@ public class RemoteComponentsTest {
           try {
             StringValue result =
                 (StringValue)
-                    payloadCodec.decodePayload(message.getData()).unpack(StringValue.class);
+                    payloadCodec
+                        .decodePayload(message.getData())
+                        .getPayload()
+                        .unpack(StringValue.class);
             resultFuture.complete(result);
           } catch (InvalidProtocolBufferException | FlammeImplRuntimeError e) {
             fail(Strings.FAILED_TO_READ_PAYLOAD);
@@ -114,9 +124,5 @@ public class RemoteComponentsTest {
     } catch (TimeoutException | ExecutionException | InterruptedException e) {
       fail(Strings.FUTURE_DID_NOT_COMPLETE, e);
     }
-  }
-
-  private static byte[] encode(Any payload) {
-    return payloadCodec.encodePayload(payload);
   }
 }

--- a/deployment/src/test/java/io/github/amadeusitgroup/flamme/test/fixtures/Components.java
+++ b/deployment/src/test/java/io/github/amadeusitgroup/flamme/test/fixtures/Components.java
@@ -66,4 +66,22 @@ public class Components {
     public final AtomicReference<Any> lastInput = new AtomicReference<>();
     public final AtomicReference<Any> lastOutput = new AtomicReference<>();
   }
+
+  @Flamme(
+      serviceName = "failing-component",
+      consumes = {"fan-out-event"},
+      produces = {"produces"})
+  public interface FailingComponent {
+    Any fail(Any args);
+  }
+
+  @FlammeImpl
+  @Unremovable
+  @ApplicationScoped
+  public static class FailingComponentImpl implements FailingComponent {
+    @Override
+    public Any fail(Any args) {
+      throw new RuntimeException("failing component failed!");
+    }
+  }
 }

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/Broker.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/Broker.java
@@ -78,18 +78,14 @@ public class Broker {
                     String replyTo = message.subject();
                     var replySubjectHandlerOptional = replySubjectHandler(replyTo);
                     if (replySubjectHandlerOptional.isEmpty()) return;
-                    Optional<FlammeError> errorMessageOptional =
-                        payloadCodec.decodeError(message.data());
-                    if (errorMessageOptional.isPresent()) {
+                    FlammeEnvelope envelope = payloadCodec.decodePayload(message.data());
+                    if (envelope.hasError()) {
                       replySubjectHandlerOptional
                           .get()
                           .completeExceptionally(
-                              new FlammeImplRuntimeError(
-                                  errorMessageOptional.get().getErrorMessage()));
+                              new FlammeImplRuntimeError(envelope.getError().getErrorMessage()));
                     } else {
-                      replySubjectHandlerOptional
-                          .get()
-                          .complete(payloadCodec.decodePayload(message.data()));
+                      replySubjectHandlerOptional.get().complete(envelope.getPayload());
                     }
                   },
                   Strings.ERROR_WHEN_RECEIVING_REPLY));
@@ -115,7 +111,12 @@ public class Broker {
     var replySubjectHandlerOptional = replySubjectHandler(subject);
     if (replySubjectHandlerOptional.isEmpty()) return false;
     var replyFuture = replySubjectHandlerOptional.get();
-    replyFuture.complete(message.payload());
+    FlammeEnvelope envelope = message.envelope();
+    if (envelope.hasError()) {
+      replyFuture.completeExceptionally(new FlammeImplRuntimeError(envelope.getError().getErrorMessage()));
+    } else {
+      replyFuture.complete(envelope.getPayload());
+    }
     return true;
   }
 
@@ -124,7 +125,7 @@ public class Broker {
     try {
       transportClient.publish(
           new TransportMessage(
-              subject, message.headers(), payloadCodec.encodePayload(message.payload()), null));
+              subject, message.headers(), payloadCodec.encodePayload(message.envelope()), null));
     } catch (Throwable t) {
     }
   }
@@ -160,7 +161,7 @@ public class Broker {
           new TransportMessage(
               subject,
               message.headers(),
-              payloadCodec.encodePayload(message.payload()),
+              payloadCodec.encodePayload(message.envelope()),
               message.replyTo());
       transportClient.publish(transportMessage);
     } catch (Throwable t) {
@@ -186,9 +187,10 @@ public class Broker {
                       ContextHelper.runWithDuplicatedContext(
                           () -> {
                             try {
-                              Any payload = payloadCodec.decodePayload(message.data());
+                              FlammeEnvelope envelope = payloadCodec.decodePayload(message.data());
                               handler.accept(
-                                  new FlammeMessage(payload, message.headers(), message.replyTo()));
+                                  new FlammeMessage(
+                                      envelope, message.headers(), message.replyTo()));
                             } catch (Throwable t) {
                               log.atError().log(Strings.failedToProcessMessage(subject));
                             }

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/ConnectionInitializer.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/ConnectionInitializer.java
@@ -39,7 +39,6 @@ public class ConnectionInitializer {
               .server(config.nats().url())
               .connectionName(config.nats().connectionName())
               .build();
-
       Connection connection = Nats.connect(options);
       natsClientManager.setConnection(connection);
     } catch (Throwable t) {

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/FlammeMessage.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/FlammeMessage.java
@@ -3,8 +3,14 @@ package io.github.amadeusitgroup.flamme.runtime;
 import com.google.protobuf.Any;
 import java.util.Map;
 
-public record FlammeMessage(Any payload, Map<String, String> headers, String replyTo) {
+public record FlammeMessage(FlammeEnvelope envelope, Map<String, String> headers, String replyTo) {
   FlammeMessage wrap(Any payload) {
-    return new FlammeMessage(payload, this.headers(), this.replyTo());
+    FlammeEnvelope envelope = FlammeEnvelope.newBuilder().setPayload(payload).build();
+    return new FlammeMessage(envelope, this.headers(), this.replyTo());
+  }
+
+  FlammeMessage error(FlammeError error) {
+    FlammeEnvelope envelope = FlammeEnvelope.newBuilder().setError(error).build();
+    return new FlammeMessage(envelope, headers, replyTo);
   }
 }

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/FlammeRecorder.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/FlammeRecorder.java
@@ -98,8 +98,9 @@ public class FlammeRecorder {
           });
       broker.subscribeForReply(replyToSbuject, replyFuture);
       Any payloadMessage = (Any) args[0];
+      FlammeEnvelope envelope = FlammeEnvelope.newBuilder().setPayload(payloadMessage).build();
       Map<String, String> headers = args.length > 1 ? (Map<String, String>) args[1] : null;
-      FlammeMessage message = new FlammeMessage(payloadMessage, headers, replyToSbuject);
+      FlammeMessage message = new FlammeMessage(envelope, headers, replyToSbuject);
       // publish messages to the gateway's producers
       for (String subject : annotation.producers()) {
         broker.publish(subject, message);

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/Handler.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/Handler.java
@@ -8,6 +8,7 @@ import io.quarkus.arc.Arc;
 import io.quarkus.arc.InstanceHandle;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,6 +26,16 @@ public class Handler {
         Any result = invoke(method, implHandle.get(), args, interfaceClass.getName());
         publish(message, outputSubjects, broker, result);
       } catch (FlammeImplRuntimeError e) {
+        // get the error message that the component raised.
+        // InvocationTargetException -> FlammeRuntimeException
+        String errorMessage =
+            Optional.ofNullable(e.getCause())
+                .map(Throwable::getCause)
+                .map(Throwable::getMessage)
+                .orElse(e.getMessage());
+        log.atDebug().addArgument(errorMessage).log("component level error message: {}");
+        FlammeError error = FlammeError.newBuilder().setErrorMessage(errorMessage).build();
+        broker.publish(message.replyTo(), message.error(error));
         log.atError().log(e.getLocalizedMessage());
       }
     };
@@ -43,8 +54,8 @@ public class Handler {
   private static Object[] constructArgs(Method method, FlammeMessage message) {
     return switch (method.getParameterCount()) {
       case 0 -> null;
-      case 1 -> new Object[] {message.payload()};
-      default -> new Object[] {message.payload(), message.headers()};
+      case 1 -> new Object[] {message.envelope().getPayload()};
+      default -> new Object[] {message.envelope().getPayload(), message.headers()};
     };
   }
 

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/payload/MultiPayloadCodec.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/payload/MultiPayloadCodec.java
@@ -1,36 +1,23 @@
 package io.github.amadeusitgroup.flamme.runtime.payload;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.github.amadeusitgroup.flamme.runtime.FlammeEnvelope;
-import io.github.amadeusitgroup.flamme.runtime.FlammeError;
 import io.github.amadeusitgroup.flamme.runtime.errors.FlammeImplRuntimeError;
 import io.github.amadeusitgroup.flamme.runtime.utils.Strings;
 import jakarta.enterprise.context.ApplicationScoped;
-import java.util.Optional;
 
 @ApplicationScoped
 public class MultiPayloadCodec implements PayloadCodec {
 
   @Override
-  public byte[] encodePayload(Any payload) {
-    return FlammeEnvelope.newBuilder().setPayload(payload).build().toByteArray();
+  public byte[] encodePayload(FlammeEnvelope envelope) {
+    return envelope.toByteArray();
   }
 
   @Override
-  public Any decodePayload(byte[] data) throws FlammeImplRuntimeError {
+  public FlammeEnvelope decodePayload(byte[] data) throws FlammeImplRuntimeError {
     try {
-      return FlammeEnvelope.parseFrom(data).getPayload();
-    } catch (InvalidProtocolBufferException e) {
-      throw new FlammeImplRuntimeError(Strings.ERROR_DECODING_REMOTE_PAYLOAD, e);
-    }
-  }
-
-  @Override
-  public Optional<FlammeError> decodeError(byte[] data) throws FlammeImplRuntimeError {
-    try {
-      var envelope = FlammeEnvelope.parseFrom(data);
-      return envelope.hasError() ? Optional.of(envelope.getError()) : Optional.empty();
+      return FlammeEnvelope.parseFrom(data);
     } catch (InvalidProtocolBufferException e) {
       throw new FlammeImplRuntimeError(Strings.ERROR_DECODING_REMOTE_PAYLOAD, e);
     }

--- a/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/payload/PayloadCodec.java
+++ b/runtime/src/main/java/io/github/amadeusitgroup/flamme/runtime/payload/PayloadCodec.java
@@ -1,14 +1,10 @@
 package io.github.amadeusitgroup.flamme.runtime.payload;
 
-import com.google.protobuf.Any;
-import io.github.amadeusitgroup.flamme.runtime.FlammeError;
+import io.github.amadeusitgroup.flamme.runtime.FlammeEnvelope;
 import io.github.amadeusitgroup.flamme.runtime.errors.FlammeImplRuntimeError;
-import java.util.Optional;
 
 public interface PayloadCodec {
-  byte[] encodePayload(Any payload);
+  byte[] encodePayload(FlammeEnvelope envelope);
 
-  Any decodePayload(byte[] data) throws FlammeImplRuntimeError;
-
-  Optional<FlammeError> decodeError(byte[] data) throws FlammeImplRuntimeError;
+  FlammeEnvelope decodePayload(byte[] data) throws FlammeImplRuntimeError;
 }

--- a/runtime/src/main/proto/envelope.proto
+++ b/runtime/src/main/proto/envelope.proto
@@ -7,8 +7,10 @@ import "google/protobuf/any.proto";
 option java_multiple_files = true;
 
 message FlammeEnvelope {
+  oneof content {
     google.protobuf.Any payload = 1;
     FlammeError error = 2;
+  }
 }
 
 message FlammeError {


### PR DESCRIPTION
## Description
When a flamme component throws an exception, it is caught and the reply future completes exceptionally. 

<!-- What does this PR do? Why is it needed? -->

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional change)
- [ ] Documentation update
- [ ] CI / build change

## Related issue
Closes #4 
<!-- Closes #<issue-number> -->

## Checklist

- [x] My changes follow the coding style of the project (`mvn spotless:check`)
- [x] I have added or updated tests to cover my changes
- [x] All existing tests pass (`mvn verify`)
- [x] I have updated the documentation if needed
